### PR TITLE
Fix version file URL property

### DIFF
--- a/PAWRangeBuff.version
+++ b/PAWRangeBuff.version
@@ -17,7 +17,7 @@
         "PATCH": 5
     }, 
     "NAME": "PAWRangeBuff", 
-    "URL": "https://raw.githubusercontent.com/atomontage04/PAWRangeBuff/master/KIS.version", 
+    "URL": "https://raw.githubusercontent.com/atomontage04/PAWRangeBuff/master/PAWRangeBuff.version", 
     "VERSION": {
         "BUILD": 0, 
         "MAJOR": 0, 

--- a/Release/GameData/PAWRangeBuff/PAWRangeBuff.version
+++ b/Release/GameData/PAWRangeBuff/PAWRangeBuff.version
@@ -17,7 +17,7 @@
         "PATCH": 5
     }, 
     "NAME": "PAWRangeBuff", 
-    "URL": "https://raw.githubusercontent.com/atomontage04/PAWRangeBuff/master/KIS.version", 
+    "URL": "https://raw.githubusercontent.com/atomontage04/PAWRangeBuff/master/PAWRangeBuff.version", 
     "VERSION": {
         "BUILD": 0, 
         "MAJOR": 0, 


### PR DESCRIPTION
The version file's `"URL"` property is invalid. This property is how KSP-AVC checks for new releases, and it also allows KSP-AVC and CKAN to update the version info for a released version without needing to modify the download files.

Now `"URL"` is fixed.

Noticed while working on KSP-CKAN/NetKAN#7874 and KSP-CKAN/NetKAN#7877.